### PR TITLE
Parameter optimization finished (w/o surface chem)

### DIFF
--- a/Looping_Runners/w_Pt_runner.py
+++ b/Looping_Runners/w_Pt_runner.py
@@ -36,7 +36,7 @@ plt.rcParams.update({'font.size': font_sz})
 #    
 #    save = user_inputs.save = 0 # change to one if wanting to save outputs
 #    w_Pt = user_inputs.w_Pt = w
-#            
+#                
 #    folder_name = user_inputs.folder_name = folder_nm_generic + str(w_Pt) + 'mgcm-2'
 #    exec(open("Shared_Funcs/pemfc_pre.py").read())
 #    exec(open("Shared_Funcs/pemfc_dsvdt.py").read())

--- a/Looping_Runners/w_Pt_runner.py
+++ b/Looping_Runners/w_Pt_runner.py
@@ -11,7 +11,7 @@ Notes:
     desired user inputs should be specified in the file pemfc_runner.py.
     
     Read through the string comments for each section and uncomment the code 
-    below it desired to produce its outputs.
+    below it in order to produce its outputs.
 """
 
 import os
@@ -26,21 +26,22 @@ font = plt.matplotlib.font_manager.FontProperties(family=font_nm, size=font_sz)
 plt.rcParams.update({'font.size': font_sz})
 
 " Loop through Pt loading polarization curves: "
-#folder_nm_generic = 'cs_Pt_loop_'
+#folder_nm_generic = 'cs_Pt_loop_' # pre-fix to all folders for saving
 #
-#w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
-##cti = ['pemfc2.cti', 'pemfc1.cti', 'pemfc05.cti', 'pemfc025.cti'] #don't uncomment
+#y_model = np.array([])
+#w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025]) # Pt-loading values to loop through
 #for i, w in enumerate(w_Pt_vec):
 #    from pemfc_runner import *
 #    import pemfc_runner as user_inputs
 #    
-#    save = user_inputs.save = 1
+#    save = user_inputs.save = 0 # change to one if wanting to save outputs
 #    w_Pt = user_inputs.w_Pt = w
+#            
 #    folder_name = user_inputs.folder_name = folder_nm_generic + str(w_Pt) + 'mgcm-2'
-##    ctifile = run.ctifile = cti[i] #don't uncomment
 #    exec(open("Shared_Funcs/pemfc_pre.py").read())
 #    exec(open("Shared_Funcs/pemfc_dsvdt.py").read())
 #    exec(open("Shared_Funcs/pemfc_post.py").read())
+#    y_model = np.hstack([y_model, dphi_ss[1:]])
 #    if save == 1:
 #        ModuleWriter(cwd +'/Saved_Results/' +folder_name +'/user_inputs.csv', user_inputs)
 
@@ -85,32 +86,32 @@ plt.rcParams.update({'font.size': font_sz})
 #    plt.tight_layout()
 #    
 #    if w_Pt == 0.2:
-#        x = np.array([0.008, 0.051, 0.201, 0.403, 0.802, 1.002, 1.202, 1.501, 
-#                      1.651, 1.851, 2.000])
+#        x = np.array([0.000, 0.050, 0.200, 0.400, 0.800, 1.000, 1.200, 1.500, 
+#                      1.650, 1.850, 2.000])
 #        y = np.array([0.952, 0.849, 0.803, 0.772, 0.731, 0.716, 0.700, 0.675, 
 #                      0.665, 0.647, 0.634])
 #        yerr = np.array([0, 0.012, 0.007, 0.007, 0.012, 0.001, 0.008, 0.007,
 #                         0.007, 0.009, 0.009])
 #        color, fmt, lbl = 'black', '-x', r'0.2 mg/cm$^$2'
 #    elif w_Pt == 0.1:
-#        x = np.array([0.006, 0.053, 0.201, 0.401, 0.802, 1.002, 1.200, 1.499, 
-#                      1.651, 1.851, 2.000])
+#        x = np.array([0.000, 0.050, 0.200, 0.400, 0.800, 1.000, 1.200, 1.500, 
+#                      1.650, 1.850, 2.000])
 #        y = np.array([0.930, 0.834, 0.785, 0.754, 0.711, 0.691, 0.673, 0.649, 
 #                      0.635, 0.615, 0.598])
 #        yerr = np.array([0, 0.009, 0.007, 0.005, 0.007, 0.011, 0.011, 0.007, 
 #                         0.009, 0.011, 0.011])
 #        color, fmt, lbl = 'black', '-o', r'0.1 mg/cm$^$2'
 #    elif w_Pt == 0.05:
-#        x = np.array([0.008, 0.053, 0.201, 0.401, 0.800, 1.000, 1.200, 1.500, 
-#                      1.651, 1.850, 2.001])
+#        x = np.array([0.000, 0.050, 0.200, 0.400, 0.800, 1.000, 1.200, 1.500, 
+#                      1.650, 1.850, 2.000])
 #        y = np.array([0.919, 0.810, 0.760, 0.724, 0.674, 0.653, 0.634, 0.603,
 #                      0.585, 0.558, 0.537])
 #        yerr = np.array([0, 0.008, 0.006, 0.006, 0.007, 0.007, 0.005, 0.005, 
 #                         0.006, 0.007, 0.007])
 #        color, fmt, lbl = 'black', '-s', r'0.05 mg/cm$^$2'
 #    elif w_Pt == 0.025:
-#        x = np.array([0.003, 0.049, 0.202, 0.404, 0.803, 1.005, 1.204, 1.503, 
-#                      1.653, 1.851, 2.004])
+#        x = np.array([0.000, 0.050, 0.200, 0.400, 0.800, 1.000, 1.200, 1.500, 
+#                      1.650, 1.850, 2.000])
 #        y = np.array([0.910, 0.785, 0.724, 0.683, 0.626, 0.598, 0.572, 0.527, 
 #                      0.502, 0.463, 0.430])
 #        yerr = np.array([0, 0.004, 0.010, 0.014, 0.013, 0.013, 0.019, 0.024, 

--- a/Shared_Funcs/pemfc_dsvdt.py
+++ b/Shared_Funcs/pemfc_dsvdt.py
@@ -346,15 +346,15 @@ iPhi_f = int(iSV['phi_dl'] + (Ny_cl-1)*L_cl/Ny_cl)
 # Update and convert i_ext: A/cm^2 -> A/m^2
 cl['i_ext'] = i_ext[0] *100**2
 
-sol = solve_ivp(lambda t,sv: dsvdt_func(t, sv, objs, p, iSV), [0, t_sim], 
+sol = solve_ivp(lambda t, sv: dsvdt_func(t, sv, objs, p, iSV), [0, t_sim], 
                 SV_0, method=method, atol=atol, rtol=rtol, max_step=max_t)
 
 # Calculate extra PEM resistance terms to subtract off:
-R_naf = i_ext*(pem['R_naf'] + 0.5*cl['dy'] / cl['sig_naf_io'] *100**2)
+R_naf_vec = i_ext*(pem['R_naf'] + 0.5*cl['dy'] / cl['sig_naf_io'] *100**2)
 
 # Store solution and update initial values:
 SV_0, sv_save[:,0] = sol.y[:,-1], np.append(i_ext[0], sol.y[:,-1])
-dphi_ss[0] = sol.y[iPhi_f, -1] - dphi_eq_an - R_naf[0]
+dphi_ss[0] = sol.y[iPhi_f, -1] - dphi_eq_an - R_naf_vec[0]
                 
 print('t_f:',sol.t[-1],'i_ext:',round(cl['i_ext']*1e-4,3), 'dPhi:',round(dphi_ss[0],3))
 
@@ -366,13 +366,13 @@ for i in range(len(i_ext) -1):
     # Update and convert i_ext: A/cm^2 -> A/m^2
     cl['i_ext'] = i_ext[i+1] *100**2
 
-    sol = solve_ivp(lambda t,sv: dsvdt_func(t, sv, objs, p, iSV), [0, t_sim], 
+    sol = solve_ivp(lambda t, sv: dsvdt_func(t, sv, objs, p, iSV), [0, t_sim], 
                     SV_0, method=method, atol=atol, rtol=rtol, max_step=max_t)
     
     # Store solution and update initial values:
     SV_0, sv_save[:,i+1] = sol.y[:,-1], np.append(i_ext[i+1], sol.y[:,-1])
 
     eta_ss[i+1] = dphi_ss[0] - sol.y[iPhi_f,-1]
-    dphi_ss[i+1] = sol.y[iPhi_f,-1] - dphi_eq_an - R_naf[i+1]
+    dphi_ss[i+1] = sol.y[iPhi_f,-1] - dphi_eq_an - R_naf_vec[i+1]
 
     print('t_f:',sol.t[-1], 'i_ext:',round(cl['i_ext']*1e-4,3), 'dPhi:',round(dphi_ss[i+1],3))

--- a/Shared_Funcs/pemfc_pre.py
+++ b/Shared_Funcs/pemfc_pre.py
@@ -48,6 +48,31 @@ gas_ca.basis = basis
 pt_s_ca.basis = basis
 naf_s_ca.basis = basis
 
+###############################################################################
+# Change parameters for optimization only:
+if optimize == 1:
+    if tog == 2:
+        R_naf = c*w_Pt**d
+    else:
+        R_naf = R_naf_opt
+        
+    theta = theta_opt
+        
+    Rxn1 = pt_s_ca.reaction(0)
+    if tog == 1:
+        i_o = abs(a*w_Pt + b)
+    else:
+        i_o = i_o_opt
+    Rxn1.rate = ct.Arrhenius(i_o, 0, 0)
+    pt_s_ca.modify_reaction(0, Rxn1)
+    
+    O2 = naf_b_ca.species(naf_b_ca.species_index('O2(Naf)'))
+    fuel_coeffs = O2.thermo.coeffs
+    fuel_coeffs[[1,8]] = np.array([3.28253784 +offset_opt, 3.782456360 +offset_opt])
+    O2.thermo = ct.NasaPoly2(200, 3500, ct.one_atm, fuel_coeffs)
+    naf_b_ca.modify_species(naf_b_ca.species_index('O2(Naf)'), O2)
+###############################################################################
+
 " Store phases in a common 'objs' dict: "
 objs = {}
 objs['carb_ca'] = carb_ca

--- a/Shared_Funcs/pemfc_pre.py
+++ b/Shared_Funcs/pemfc_pre.py
@@ -52,7 +52,7 @@ naf_s_ca.basis = basis
 # Change parameters for optimization only:
 if optimize == 1:
     if tog == 2:
-        R_naf = (c*w_Pt**d + 35) *1e-3
+        R_naf = (c*w_Pt**d + e) *1e-3
     else:
         R_naf = R_naf_opt
         

--- a/Shared_Funcs/pemfc_pre.py
+++ b/Shared_Funcs/pemfc_pre.py
@@ -52,7 +52,7 @@ naf_s_ca.basis = basis
 # Change parameters for optimization only:
 if optimize == 1:
     if tog == 2:
-        R_naf = c*w_Pt**d
+        R_naf = (c*w_Pt**d + 35) *1e-3
     else:
         R_naf = R_naf_opt
         
@@ -60,7 +60,7 @@ if optimize == 1:
         
     Rxn1 = pt_s_ca.reaction(0)
     if tog == 1:
-        i_o = abs(a*w_Pt + b)
+        i_o = a*w_Pt + b
     else:
         i_o = i_o_opt
     Rxn1.rate = ct.Arrhenius(i_o, 0, 0)

--- a/fitting_optimization.py
+++ b/fitting_optimization.py
@@ -1,0 +1,194 @@
+"""
+Created on Wed Jun 19 11:13:05 2019
+
+Author: Corey R. Randall
+
+Optimization routine:
+    Minimize the error between the data from Owejan et. al. paper and the PEMFC
+    models (core-shell and flooded-agglomerate) by varying the following:
+    theta, offset, R_naf, and i_o. 
+    
+Instructions:
+    To use this script, open up the pemfc_runner.py file and comment out the 
+    lines of code that specify R_naf, w_Pt, and theta. Use the lines of code
+    below to input i_OCV, i_ext1, i_ext2, and i_ext3 into pemfc_runner.py. Once
+    these items have been complete, fill out the initial guess values for the 
+    optimization in 'p0' in the order commented below. Ranges for each of these
+    parameters should also be specified in the 'bounds' variable below. Simply
+    run this script after these inputs have been filled out and allow for the 
+    error to be minimized for the data sets using scipy.optimize.minize.
+"""
+
+import numpy as np
+import cantera as ct
+
+# How to set up i_ext vector:
+"""
+i_OCV = 0
+i_ext1 = np.array([0.05, 0.20, 0.40, 0.80, 1.0, 1.2, 1.5, 1.65, 1.85, 2.0])
+i_ext2 = np.array([])
+i_ext3 = np.array([])"""
+
+# User Inputs for optimization of R_naf, theta, i_o, and offset:
+p0 = np.array([45e-3, 50, 4e-6, 0.5]) # R_naf [Ohm*m^2], theta [degrees], i_o, offset
+bounds0 = np.array([[20e-3, 120e-3], [50, 80], [1e-6, 9e-6], [0.3, 1.0]]) # [min, max]
+
+# User Inputs for optimization of R_naf, theta, offset, a, and b from i_o = a*w_Pt + b:
+p1 = np.array([45e-3, 50, 0.5, 23e-6, -0.6e-6])
+bounds1 = np.array([[20e-3, 120e-3], [50, 80], [0.3, 1.0], [1e-6, 50e-6], [-1e-6, 1e-6]])
+
+# User Inputs for optimization of theta, i_o, offset, c, and d from R_naf = c*w_Pt^d:
+p2 = np.array([])
+bounds = np.array([])
+
+# Toggle for which optimization to run:
+tog = 1
+
+""" Do not edit anything below this line """
+"-----------------------------------------------------------------------------"
+###############################################################################
+###############################################################################
+###############################################################################
+
+# Data to fit for different Pt loadings (x,y) -> (i [A/cm^2], Phi [V]):
+" All x values are shared and y* is the y data, s* is the error bars (+/-) "
+x = np.array([0.0, 0.05, 0.20, 0.40, 0.80, 1.0, 1.2, 1.5, 1.65, 1.85, 2.0])
+y1 = np.array([0.95, 0.85, 0.80, 0.77, 0.73, 0.72, 0.70, 0.68, 0.67, 0.65, 0.63]) # w_Pt = 0.2 mg/cm^2
+s1 = np.array([0.1, 12, 7, 7, 12, 1, 8, 7, 7, 9, 9]) *1e-3 
+
+y2 = np.array([0.93, 0.83, 0.79, 0.75, 0.71, 0.69, 0.67, 0.65, 0.64, 0.62, 0.60]) # w_Pt = 0.1 mg/cm^2
+s2 = np.array([0.1, 9, 7, 5, 7, 11, 11, 7, 9, 11, 11]) *1e-3
+
+y3 = np.array([0.92, 0.81, 0.76, 0.72, 0.67, 0.65, 0.63, 0.60, 0.59, 0.56, 0.54]) # w_Pt = 0.05 mg/cm^2
+s3 = np.array([0.1, 8, 6, 6, 7, 7, 5, 5, 6, 7, 7]) *1e-3
+
+y4 = np.array([0.91, 0.79, 0.72, 0.68, 0.63, 0.60, 0.57, 0.53, 0.50, 0.46, 0.43]) # w_Pt = 0.025 mg/cm^2
+s4 = np.array([0.1, 4, 10, 14, 13, 13, 19, 24, 25, 23, 24]) *1e-3
+
+# Scipy optimization (try now) vs scikits-learn (later??):
+optimize = 1 # tell pre processor to reset optimized parameters
+
+from scipy.optimize import minimize
+y_data = np.hstack([y1, y2, y3, y4])
+s_data = np.hstack([s1, s2, s3, s4])
+
+def chi_sq_func0(p_opt): # p_opt[:] = R_naf, theta, i_o, offset
+    
+    global w_Pt, R_naf_opt, theta_opt, i_o_opt, offset_opt
+    R_naf_opt, theta_opt, i_o_opt, offset_opt = p_opt
+    print('\n\nR_naf, theta, i_o, offset:', p_opt)
+    
+    y_model = np.array([])
+    w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
+    for i, w in enumerate(w_Pt_vec):
+        w_Pt = w
+        exec(open("pemfc_runner.py").read(), globals(), globals())
+        y_model = np.hstack([y_model, dphi_ss])
+        
+    chi_sq = sum((y_data - y_model)**2 / s_data**2)
+    print('\nchi_sq:', chi_sq)
+    
+    return chi_sq
+
+# Results for by-hand fit: (comparison to tog = 0)
+"""
+chi_sq = 9148406.997429071
+
+R_naf = user_inputs.R_naf = 
+theta = user_inputs.theta = 45
+i_o = 4e-6
+offset = 0.55"""
+
+# Results for tog = 0:
+"""
+chi_sq = 8551703.012265678
+
+R_naf = user_inputs.R_naf = 78.3872409e-3
+theta = user_inputs.theta = 62.4837816
+i_o = 5.09982691e-6
+offset = 1.0"""
+
+def chi_sq_func1(p_opt): # p_opt[:] = R_naf, theta, offset, a, b
+    w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
+    
+    global w_Pt, R_naf_opt, theta_opt, offset_opt, a, b
+    R_naf_opt, theta_opt, offset_opt, a, b = p_opt
+    print('\n\nR_naf, theta, offset, a, b:', p_opt, 'i_o:', abs(a*w_Pt_vec + b))
+    
+    y_model = np.array([])
+    for i, w in enumerate(w_Pt_vec):
+        w_Pt = w
+        exec(open("pemfc_runner.py").read(), globals(), globals())
+        y_model = np.hstack([y_model, dphi_ss])
+        
+    chi_sq = sum((y_data - y_model)**2 / s_data**2)
+    print('\nchi_sq:', chi_sq)
+    
+    return chi_sq
+
+# Results for by-hand with varying i_o: (comparison to tog = 1)
+"""
+chi_sq = 
+
+R_naf = user_inputs.R_naf = 
+theta = user_inputs.theta = 
+offset = 
+a = 
+b = """
+    
+# Results for tog = 1:
+"""
+chi_sq = 
+
+R_naf = user_inputs.R_naf = 
+theta = user_inputs.theta =
+offset = 
+a = 
+b = """
+
+def chi_sq_func2(p_opt): # p_opt[:] = theta, offset, i_o, c, d
+    w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
+    
+    global w_Pt, theta_opt, offset_opt, i_o_opt, c, d
+    theta_opt, offset_opt, i_o_opt, c, d = p_opt
+    print('\n\ntheta, offset, i_o, c, d:', p_opt, 'R_naf:', c*w_Pt_vec**d)
+    
+    y_model = np.array([])
+    for i, w in enumerate(w_Pt_vec):
+        w_Pt = w
+        exec(open("pemfc_runner.py").read(), globals(), globals())
+        y_model = np.hstack([y_model, dphi_ss])
+        
+    chi_sq = sum((y_data - y_model)**2 / s_data**2)
+    print('\nchi_sq:', chi_sq)
+    
+    return chi_sq
+
+# Results for by-hand with varying R_naf: (comparison to tog = 2)
+"""
+chi_sq = 
+
+theta = user_inputs.theta = 
+offset = 
+i_o = 
+c = 
+d = """
+    
+# Results for tog = 2:
+"""
+chi_sq = 
+
+theta = user_inputs.theta = 
+offset = 
+i_o = 
+c = 
+d = """
+
+if tog == 0:
+    res = minimize(chi_sq_func0, p0, method='L-BFGS-B', bounds=bounds0)
+elif tog == 1:
+    res = minimize(chi_sq_func1, p1, method='L-BFGS-B', bounds=bounds1)
+elif tog == 2:
+    res = minimize(chi_sq_func2, p2, method='L-BFGS-B', bounds=bounds2)
+    
+    

--- a/fitting_optimization.py
+++ b/fitting_optimization.py
@@ -10,19 +10,37 @@ Optimization routine:
     
 Instructions:
     To use this script, open up the pemfc_runner.py file and comment out the 
-    lines of code that specify R_naf, w_Pt, and theta. Use the lines of code
+    line of code that specifies w_Pt. Copy and paste the lines of code
     below to input i_OCV, i_ext1, i_ext2, and i_ext3 into pemfc_runner.py. Once
     these items have been complete, fill out the initial guess values for the 
-    optimization in 'p0' in the order commented below. Ranges for each of these
-    parameters should also be specified in the 'bounds' variable below. Simply
-    run this script after these inputs have been filled out and allow for the 
-    error to be minimized for the data sets using scipy.optimize.minize.
+    optimization in 'p0', 'p1', or 'p2' in the order commented below. Ranges 
+    for each of these parameters should also be specified in the respective 
+    'bounds*' variable below. Simply run this script after these inputs have 
+    been filled out and allow for the error to be minimized for the data sets 
+    using the package scipy.optimize.minize.
+    
+Optimization options:
+    The 'tog' variable can be set to 0, 1, or 2 in order to change which set of
+    parameters are being varied in the optmization. When tog = 0 then R_naf, 
+    theta, i_o, and offset are all varied and assumed to be constant accross all
+    Pt loadings. If tog = 1 then the same parameters are varied except i_o is
+    treated as a function of Pt loading as i_o = a*w_Pt + b which allows both a
+    and b to be varied instead of just a constant i_o. The last case is when 
+    tog = 2 which again assumes the same parameters are being varied except that
+    R_naf is treated as a function of Pt loading instead of i_o. The form of 
+    this function is R_naf = (c*w_Pt^d +35)*1e-3 where c and d become the fitting 
+    parameters.
+    
+Units for inputs:
+    R_naf [Ohm*cm^2], theta [degrees], i_o [A/cm^2 *(cm^3/kmol)^6.5], offset [-], 
+    a [A/cm^2 *(cm^3/kmol)^6.5 /(mg/cm^2)], b [A/cm^2 *(cm^3/kmol)^6.5], 
+    c [mOhm*cm^2 /(mg/cm^2)], and d [-].
 """
 
 import numpy as np
 import cantera as ct
 
-# How to set up i_ext vector:
+# How to set up i_ext vector in the pemfc_runner.py file:
 """
 i_OCV = 0
 i_ext1 = np.array([0.05, 0.20, 0.40, 0.80, 1.0, 1.2, 1.5, 1.65, 1.85, 2.0])
@@ -30,18 +48,20 @@ i_ext2 = np.array([])
 i_ext3 = np.array([])"""
 
 # User Inputs for optimization of R_naf, theta, i_o, and offset:
-p0 = np.array([45e-3, 50, 4e-6, 0.5]) # R_naf [Ohm*m^2], theta [degrees], i_o, offset
-bounds0 = np.array([[20e-3, 120e-3], [50, 80], [1e-6, 9e-6], [0.3, 1.0]]) # [min, max]
+p0 = np.array([45e-3, 45, 4e-6, 0.55]) 
+bounds0 = np.array([[20e-3, 120e-3], [42.5, 80], [1e-6, 9e-6], [0.52, 1.0]]) # [min, max]
 
 # User Inputs for optimization of R_naf, theta, offset, a, and b from i_o = a*w_Pt + b:
-p1 = np.array([45e-3, 50, 0.5, 23e-6, -0.6e-6])
-bounds1 = np.array([[20e-3, 120e-3], [50, 80], [0.3, 1.0], [1e-6, 50e-6], [-1e-6, 1e-6]])
+p1 = np.array([45e-3, 45, 0.55, 24.5e-6, -0.60e-6])
+p1 = np.array([54.6322292e-3, 44.9866196, 0.545933492, 24.18e-6, -0.441002786e-6])
+bounds1 = np.array([[20e-3, 120e-3], [42.5, 80], [0.52, 1.0], [24.17e-6, 50e-6], [-0.5e-6, 1e-6]])
 
-# User Inputs for optimization of theta, i_o, offset, c, and d from R_naf = c*w_Pt^d:
-p2 = np.array([])
-bounds = np.array([])
+# User Inputs for optimization of theta, i_o, offset, c, and d from R_naf = (c*w_Pt^d +35)*1e-3:
+p2 = np.array([45, 2e-6, 0.55, 0.874, -1.083])
+#p2 = np.array([50, 1.58523583e-6, 0.535449905, 0.995444795, -1.16389853])
+bounds2 = np.array([[42.5, 80], [5e-7, 9e-6], [0.52, 1.0], [0., 1.5], [-1.5, 0.]])
 
-# Toggle for which optimization to run:
+# Toggle for which optimization to run (0, 1, or 2):
 tog = 1
 
 """ Do not edit anything below this line """
@@ -69,8 +89,8 @@ s4 = np.array([0.1, 4, 10, 14, 13, 13, 19, 24, 25, 23, 24]) *1e-3
 optimize = 1 # tell pre processor to reset optimized parameters
 
 from scipy.optimize import minimize
-y_data = np.hstack([y1, y2, y3, y4])
-s_data = np.hstack([s1, s2, s3, s4])
+y_data = np.hstack([y1[1:], y2[1:], y3[1:], y4[1:]])
+s_data = np.hstack([s1[1:], s2[1:], s3[1:], s4[1:]])
 
 def chi_sq_func0(p_opt): # p_opt[:] = R_naf, theta, i_o, offset
     
@@ -83,7 +103,7 @@ def chi_sq_func0(p_opt): # p_opt[:] = R_naf, theta, i_o, offset
     for i, w in enumerate(w_Pt_vec):
         w_Pt = w
         exec(open("pemfc_runner.py").read(), globals(), globals())
-        y_model = np.hstack([y_model, dphi_ss])
+        y_model = np.hstack([y_model, dphi_ss[1:]])
         
     chi_sq = sum((y_data - y_model)**2 / s_data**2)
     print('\nchi_sq:', chi_sq)
@@ -92,34 +112,35 @@ def chi_sq_func0(p_opt): # p_opt[:] = R_naf, theta, i_o, offset
 
 # Results for by-hand fit: (comparison to tog = 0)
 """
-chi_sq = 9148406.997429071
+chi_sq = 884.6912413825394
 
-R_naf = user_inputs.R_naf = 
-theta = user_inputs.theta = 45
+R_naf = user_inputs.R_naf = 45e-3
+theta = user_inputs.theta = 45.
 i_o = 4e-6
 offset = 0.55"""
 
 # Results for tog = 0:
 """
-chi_sq = 8551703.012265678
+chi_sq = 442.3504466112417
 
-R_naf = user_inputs.R_naf = 78.3872409e-3
-theta = user_inputs.theta = 62.4837816
-i_o = 5.09982691e-6
-offset = 1.0"""
+R_naf = user_inputs.R_naf = 47.0708165e-3
+theta = user_inputs.theta = 44.9310232
+i_o = 1.47659887e-6
+offset = 0.549173549"""
 
 def chi_sq_func1(p_opt): # p_opt[:] = R_naf, theta, offset, a, b
     w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
     
     global w_Pt, R_naf_opt, theta_opt, offset_opt, a, b
     R_naf_opt, theta_opt, offset_opt, a, b = p_opt
-    print('\n\nR_naf, theta, offset, a, b:', p_opt, 'i_o:', abs(a*w_Pt_vec + b))
+    print('\n\nR_naf, theta, offset, a, b:', p_opt)
+    print('i_o:', abs(a*w_Pt_vec + b))
     
     y_model = np.array([])
     for i, w in enumerate(w_Pt_vec):
         w_Pt = w
         exec(open("pemfc_runner.py").read(), globals(), globals())
-        y_model = np.hstack([y_model, dphi_ss])
+        y_model = np.hstack([y_model, dphi_ss[1:]])
         
     chi_sq = sum((y_data - y_model)**2 / s_data**2)
     print('\nchi_sq:', chi_sq)
@@ -128,36 +149,37 @@ def chi_sq_func1(p_opt): # p_opt[:] = R_naf, theta, offset, a, b
 
 # Results for by-hand with varying i_o: (comparison to tog = 1)
 """
-chi_sq = 
+chi_sq = 403.90458836954605
 
-R_naf = user_inputs.R_naf = 
-theta = user_inputs.theta = 
-offset = 
-a = 
-b = """
+R_naf = user_inputs.R_naf = 45e-3
+theta = user_inputs.theta = 45.
+offset = 0.55
+a = 24.5e-6
+b = -0.60e-6"""
     
 # Results for tog = 1:
 """
-chi_sq = 
+chi_sq = 111.3265875677507
 
-R_naf = user_inputs.R_naf = 
-theta = user_inputs.theta =
-offset = 
-a = 
-b = """
+R_naf = user_inputs.R_naf = 54.4607050e-3
+theta = user_inputs.theta = 44.9763477
+offset = 0.545805050
+a = 24.17e-6
+b = -0.434032963e-6"""
 
-def chi_sq_func2(p_opt): # p_opt[:] = theta, offset, i_o, c, d
+def chi_sq_func2(p_opt): # p_opt[:] = theta, i_o, offset, c, d
     w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
     
-    global w_Pt, theta_opt, offset_opt, i_o_opt, c, d
-    theta_opt, offset_opt, i_o_opt, c, d = p_opt
-    print('\n\ntheta, offset, i_o, c, d:', p_opt, 'R_naf:', c*w_Pt_vec**d)
+    global w_Pt, theta_opt, i_o_opt, offset_opt, c, d
+    theta_opt, i_o_opt, offset_opt, c, d = p_opt
+    print('\n\ntheta, i_o, offset, c, d:', p_opt)
+    print('R_naf:', (c*w_Pt_vec**d + 35) *1e-3)
     
     y_model = np.array([])
     for i, w in enumerate(w_Pt_vec):
         w_Pt = w
         exec(open("pemfc_runner.py").read(), globals(), globals())
-        y_model = np.hstack([y_model, dphi_ss])
+        y_model = np.hstack([y_model, dphi_ss[1:]])
         
     chi_sq = sum((y_data - y_model)**2 / s_data**2)
     print('\nchi_sq:', chi_sq)
@@ -166,23 +188,23 @@ def chi_sq_func2(p_opt): # p_opt[:] = theta, offset, i_o, c, d
 
 # Results for by-hand with varying R_naf: (comparison to tog = 2)
 """
-chi_sq = 
+chi_sq = 203.66835835935382
 
-theta = user_inputs.theta = 
-offset = 
-i_o = 
-c = 
-d = """
+theta = user_inputs.theta = 45.
+i_o = 2e-6
+offset = 0.55
+c = 0.874
+d = -1.083"""
     
 # Results for tog = 2:
 """
-chi_sq = 
+chi_sq = 69.49687105275932
 
-theta = user_inputs.theta = 
-offset = 
-i_o = 
-c = 
-d = """
+theta = user_inputs.theta = 50.2228419
+i_o = 1.27966523e-6
+offset = 0.653522006
+c = 0.929923592
+d = -1.24932356"""
 
 if tog == 0:
     res = minimize(chi_sq_func0, p0, method='L-BFGS-B', bounds=bounds0)
@@ -190,5 +212,22 @@ elif tog == 1:
     res = minimize(chi_sq_func1, p1, method='L-BFGS-B', bounds=bounds1)
 elif tog == 2:
     res = minimize(chi_sq_func2, p2, method='L-BFGS-B', bounds=bounds2)
+    
+# Use this in w_Pt_runner to see what plots look like:
+""" Post this line of code in w_Pt_runner.py between line 38 and line 40. Set
+the tog value to the correct option (0, 1, or 2) based on what parameters are
+being varied. Then set the needed values equal to their optimal parameters while
+commenting out any that are unneeded. Run w_Pt_runner.py once done to see the
+results.
+
+optimize, tog = 1, 1
+R_naf_opt = user_inputs.R_naf = 54.4607050e-3
+theta_opt = user_inputs.theta = 44.9763477
+i_o_opt = 1.27966523e-6
+offset_opt = 0.545805050
+a = 24.17e-6
+b = -0.434032963e-6
+c = 0.929923592
+d = -1.24932356"""
     
     

--- a/fitting_optimization.py
+++ b/fitting_optimization.py
@@ -12,7 +12,7 @@ Instructions:
     To use this script, open up the pemfc_runner.py file and comment out the 
     line of code that specifies w_Pt. Copy and paste the lines of code
     below to input i_OCV, i_ext1, i_ext2, and i_ext3 into pemfc_runner.py. Once
-    these items have been complete, fill out the initial guess values for the 
+    these items have been completed, fill out the initial guess values for the 
     optimization in 'p0', 'p1', or 'p2' in the order commented below. Ranges 
     for each of these parameters should also be specified in the respective 
     'bounds*' variable below. Simply run this script after these inputs have 
@@ -28,13 +28,13 @@ Optimization options:
     and b to be varied instead of just a constant i_o. The last case is when 
     tog = 2 which again assumes the same parameters are being varied except that
     R_naf is treated as a function of Pt loading instead of i_o. The form of 
-    this function is R_naf = (c*w_Pt^d +35)*1e-3 where c and d become the fitting 
-    parameters.
+    this function is R_naf = (c*w_Pt^d +e)*1e-3 where c, d, and e become the 
+    fitting parameters.
     
 Units for inputs:
-    R_naf [Ohm*cm^2], theta [degrees], i_o [A/cm^2 *(cm^3/kmol)^6.5], offset [-], 
+    R_naf [mOhm*cm^2], theta [degrees], i_o [A/cm^2 *(cm^3/kmol)^6.5], offset [-], 
     a [A/cm^2 *(cm^3/kmol)^6.5 /(mg/cm^2)], b [A/cm^2 *(cm^3/kmol)^6.5], 
-    c [mOhm*cm^2 /(mg/cm^2)], and d [-].
+    c [mOhm*cm^2 /(mg/cm^2)], and d [-], e [mOhm*cm^2].
 """
 
 import numpy as np
@@ -52,17 +52,15 @@ p0 = np.array([45e-3, 45, 4e-6, 0.55])
 bounds0 = np.array([[20e-3, 120e-3], [42.5, 80], [1e-6, 9e-6], [0.52, 1.0]]) # [min, max]
 
 # User Inputs for optimization of R_naf, theta, offset, a, and b from i_o = a*w_Pt + b:
-p1 = np.array([45e-3, 45, 0.55, 24.5e-6, -0.60e-6])
-p1 = np.array([54.6322292e-3, 44.9866196, 0.545933492, 24.18e-6, -0.441002786e-6])
+p1 = np.array([55e-3, 45, 0.55, 24.2e-6, -0.40e-6])
 bounds1 = np.array([[20e-3, 120e-3], [42.5, 80], [0.52, 1.0], [24.17e-6, 50e-6], [-0.5e-6, 1e-6]])
 
-# User Inputs for optimization of theta, i_o, offset, c, and d from R_naf = (c*w_Pt^d +35)*1e-3:
-p2 = np.array([45, 2e-6, 0.55, 0.874, -1.083])
-#p2 = np.array([50, 1.58523583e-6, 0.535449905, 0.995444795, -1.16389853])
-bounds2 = np.array([[42.5, 80], [5e-7, 9e-6], [0.52, 1.0], [0., 1.5], [-1.5, 0.]])
+# User Inputs for optimization of theta, i_o, offset, c, d, e from R_naf = (c*w_Pt^d +e)*1e-3:
+p2 = np.array([50, 1.3e-6, 0.65, 0.929, -1.249, 35])
+bounds2 = np.array([[42.5, 80], [5e-7, 9e-6], [0.52, 1.0], [0., 1.5], [-1.5, 0.], [0., 120.]])
 
 # Toggle for which optimization to run (0, 1, or 2):
-tog = 1
+tog = 2
 
 """ Do not edit anything below this line """
 "-----------------------------------------------------------------------------"
@@ -170,8 +168,8 @@ b = -0.434032963e-6"""
 def chi_sq_func2(p_opt): # p_opt[:] = theta, i_o, offset, c, d
     w_Pt_vec = np.array([0.2, 0.1, 0.05, 0.025])
     
-    global w_Pt, theta_opt, i_o_opt, offset_opt, c, d
-    theta_opt, i_o_opt, offset_opt, c, d = p_opt
+    global w_Pt, theta_opt, i_o_opt, offset_opt, c, d, e
+    theta_opt, i_o_opt, offset_opt, c, d, e = p_opt
     print('\n\ntheta, i_o, offset, c, d:', p_opt)
     print('R_naf:', (c*w_Pt_vec**d + 35) *1e-3)
     
@@ -194,17 +192,19 @@ theta = user_inputs.theta = 45.
 i_o = 2e-6
 offset = 0.55
 c = 0.874
-d = -1.083"""
+d = -1.083
+e = 35."""
     
 # Results for tog = 2:
 """
-chi_sq = 69.49687105275932
+chi_sq = 65.40625573579791
 
-theta = user_inputs.theta = 50.2228419
-i_o = 1.27966523e-6
-offset = 0.653522006
-c = 0.929923592
-d = -1.24932356"""
+theta = user_inputs.theta = 50.0625811
+i_o = 2.06131753e-6
+offset = 0.655151490
+c = 0.915326473
+d = -1.23061654
+e = 34.5429028"""
 
 if tog == 0:
     res = minimize(chi_sq_func0, p0, method='L-BFGS-B', bounds=bounds0)
@@ -222,12 +222,13 @@ results.
 
 optimize, tog = 1, 1
 R_naf_opt = user_inputs.R_naf = 54.4607050e-3
-theta_opt = user_inputs.theta = 44.9763477
-i_o_opt = 1.27966523e-6
-offset_opt = 0.545805050
+theta_opt = user_inputs.theta = 50.0625811
+i_o_opt = 2.06131753e-6
+offset_opt = 0.655151490
 a = 24.17e-6
 b = -0.434032963e-6
-c = 0.929923592
-d = -1.24932356"""
+c = 0.915326473
+d = -1.23061654
+e = 34.5429028"""
     
     

--- a/pemfc_runner.py
+++ b/pemfc_runner.py
@@ -74,13 +74,18 @@ import cantera as ct
 "-----------------------------------------------------------------------------"
 model = 'core_shell'                # CL geom: 'core_shell' or 'flooded_agg'
 ctifile = 'pemfc_cs.cti'            # cantera input file to match chosen model
-ver = 1                             # debugging radial diffusion (1:cs, 1-2:fa)
+ver = 1                             # debugging radial diffusion (1:cs, 2:fa)
 
 " Initial electrochemical values "
 i_OCV = 0                           # 0 [A/cm^2] -> or single run if != 0 
-i_ext0 = np.linspace(0.001,0.1,5)   # external currents close to 0 [A/cm^2]
-i_ext1 = np.linspace(0.101,1.0,5)   # external currents [A/cm^2]
-i_ext2 = np.linspace(1.100,2.0,5)   # external currents further from 0 [A/cm^2]
+i_ext0 = np.array([0.05, 0.20, 0.40, 0.80, 1.0, 1.2, 1.5, 1.65, 1.85, 2.0])
+i_ext1 = np.array([])
+i_ext2 = np.array([])
+
+#i_ext0 = np.linspace(0.001,0.1,5)   # external currents close to 0 [A/cm^2]
+#i_ext1 = np.linspace(0.101,1.0,5)   # external currents [A/cm^2]
+#i_ext2 = np.linspace(1.100,2.0,5)   # external currents further from 0 [A/cm^2]
+
 phi_ca_init = 0.7                   # initial cathode potential [V]
 T_ca, P_ca = 333, 1.5*ct.one_atm    # cathode temp [K] and pressure [Pa] at t = 0
 T_an, P_an = 333, 1.5*ct.one_atm    # anode temp [K] and pressure [Pa] at t = 0
@@ -95,7 +100,7 @@ R_naf = 45e-3        # resistance of Nafion membrane [Ohm*cm^2] (45:cs, 60:fa)
 " Pt loading and geometric values "
 area_calcs = 1      # control for area calculations [0:p_Pt, 1:Pt_loading]
 p_Pt = 10           # percentage of Pt covering the carbon particle surface [%]
-w_Pt = 0.2          # loading of Pt on carbon [mg/cm^2]
+#w_Pt = 0.2          # loading of Pt on carbon [mg/cm^2]
 rho_Pt = 21.45e3    # density of Pt for use in area property calcs [kg/m^3]
 r_c = 50e-9         # radius of single carbon particle [m] (50:cs, 25:fa)
 r_Pt = 1e-9         # radius of Pt 1/2 sphere sitting on C surface [m]
@@ -124,8 +129,8 @@ ind_e = 0           # index of electrons in Pt surface phase... from cti
 method = 'BDF'      # method for solve_ivp [eg: BDF,RK45,LSODA,Radau,etc...]
 t_sim = 1e2         # time span of integration [s]
 Ny_gdl = 3          # number of depth discretizations for GDL
-Ny_cl = 5           # number of depth discretizations for CL
-Nr_cl = 5           # number of radial discretizations for CL nafion shells
+Ny_cl = 3           # number of depth discretizations for CL
+Nr_cl = 3           # number of radial discretizations for CL nafion shells
 
 " Modify tolerance for convergence "
 max_t = t_sim       # maximum allowable time step for solver [s]
@@ -136,13 +141,13 @@ rtol = 1e-6         # relative tolerance passed to solver
 post_only = 0       # turn on to only run post-processing
 debug = 0           # turn on to plot first node variables vs time
 radial = 0          # turn on radial O2 plots for each Nafion shell
-grads = 0           # turn on to plot O2 and Phi gradients in depth of cathode
+grads = 0           # turn on to plot O2, Phi, i_far gradients vs depth of CL
 polar = 1           # turn on to generate full cell polarization curves
 over_p = 0          # turn on to plot overpotential curve for cathode side
 
 " Verification settings "
 i_ver = 0           # verify current between GDL and CL with O2 flux calcs
-i_find = 0.5        # current from polarization curve to use in i_ver processing
+i_find = 0.0001     # current from polarization curve to use in i_ver processing
 
 " Plotting options "
 font_nm = 'Arial'   # name of font for plots
@@ -157,6 +162,13 @@ save = 0                        # toggle saving on/off with '1' or '0'
 ###############################################################################
 ###############################################################################
 ###############################################################################
+
+if model == 'core_shell': 
+    ctifile, ver, R_naf, r_c = 'pemfc_cs.cti', 1, 45e-3, 50e-9
+    sig_method, D_O2_method = 'mix', 'mix'
+elif model == 'flooded_agg': 
+    ctifile, ver, R_naf, r_c = 'pemfc_fa.cti', 2, 60e-3, 25e-9
+    sig_method, D_O2_method = 'sun', 'sun'
 
 """ Process inputs from this file and run model """
 "-----------------------------------------------------------------------------"


### PR DESCRIPTION
Using scipy.optimize.minimize, a routine was written to minimize the chi_sq between the model output and data from Owejan et. al. Three cases were used for different sets of parameters as listed below:

1.) Constant R_naf, theta, i_o, and offset for all Pt loadings
2.) Constant R_naf, theta, and offset for all Pt loadings. Instead of a constant i_o, parameters a and b were varied and i_o was treated as a linear function of Pt loading (i.e. i_o = a*w_Pt + b).
3.) Constant theta, i_o, and offset for all Pt loadings. Instead of a constant R_naf, parameters c and d were varied and R_naf was treated as a power function of Pt loading (i.e. R_naf = (c*w_Pt^d + 35) *1e3).

In all cases, the chi_sq values were reduced and shown to be lower than the fits done by hand. Strictly based on the chi_sq value, case 3 provided the best fit followed by case 2 and then case 1.

Note that this base case optimization was done still assuming a global reaction and before incorporating the surface chemistry into the Pt phase.